### PR TITLE
Server is now http2 + Allow resize based on height

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const fullWidthImage = buildUrl(imagePath);
 // will output something like '//img.mapado.net/2018/01/foo.jpg'
 ```
 
-You can also specify a `width` and a `height` to crop the image:
+You can also specify a `width` and a `height` to crop / resize the image:
 
 ```js
 const width = 400;
@@ -31,4 +31,15 @@ const height = 300;
 const cropedImage = buildUrl(imagePath, width, height);
 
 // will output something like '//img.mapado.net/2018/01/foo_thumbs/400-300.jpg'
+```
+
+If you don't want to resize or apply any filter but want to allow `webp` format for compatible browser, you have two options:
+- you can set the option `allowWebp: 1`
+- you can set both width and height to `0`
+
+```js
+const webpAllowedImage = buildUrl(imagePath, null, null, {allowWebp: 1});
+const alsoWebpAllowedImage = buildUrl(imagePath, 0, 0);
+
+// will both output something like '//img.mapado.net/2018/01/foo.jpg_thumbs/0-0.jpg'
 ```

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ const cropedImage = buildUrl(imagePath, width, height);
 ```
 
 If you don't want to resize or apply any filter but want to allow `webp` format for compatible browser, you have two options:
-- you can set the option `allowWebp: 1`
+- you can set the option `allowwebp: 1`
 - you can set both width and height to `0`
 
 ```js
-const webpAllowedImage = buildUrl(imagePath, null, null, {allowWebp: 1});
+const webpAllowedImage = buildUrl(imagePath, null, null, {allowwebp: 1});
 const alsoWebpAllowedImage = buildUrl(imagePath, 0, 0);
 
 // will both output something like '//img.mapado.net/2018/01/foo.jpg_thumbs/0-0.jpg'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,11 +8,11 @@ describe('UrlBuilder tests', () => {
 
   test('handle basic url generation', () => {
     expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg')).toBe(
-      '//img1.mapado.net/2016/5/9/toto.jpg'
+      '//img.mapado.net/2016/5/9/toto.jpg'
     );
 
     expect(UrlBuilder.buildUrl('2016/5/9/toto')).toBe(
-      '//img1.mapado.net/2016/5/9/toto'
+      '//img.mapado.net/2016/5/9/toto'
     );
 
     expect(UrlBuilder.buildUrl('2016/5/10/toto.jpg')).toBe(
@@ -22,10 +22,19 @@ describe('UrlBuilder tests', () => {
 
   test('handle croping width and height', () => {
     expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', 400, 300)).toBe(
-      '//img1.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.jpg'
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', 0, 300)).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/0-300.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', 400, 0)).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-0.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', 400)).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-0.jpg'
     );
     expect(UrlBuilder.buildUrl('2016/5/9/toto', 400, 300)).toBe(
-      '//img1.mapado.net/2016/5/9/toto_thumbs/400-300'
+      '//img.mapado.net/2016/5/9/toto_thumbs/400-300'
     );
   });
 
@@ -36,12 +45,12 @@ describe('UrlBuilder tests', () => {
         blackwhite: 1,
       })
     ).toBe(
-      '//img1.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.avoid-blur=1;blackwhite=1.jpg'
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.avoid-blur=1;blackwhite=1.jpg'
     );
     expect(
       UrlBuilder.buildUrl('2016/5/9/toto.jpg', 400, 300, { blackwhite: 1 })
     ).toBe(
-      '//img1.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.blackwhite=1.jpg'
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.blackwhite=1.jpg'
     );
   });
 });
@@ -49,7 +58,7 @@ describe('UrlBuilder tests', () => {
 describe('const import', () => {
   test('const import', () => {
     expect(buildUrl('2016/5/9/toto.jpg')).toBe(
-      '//img1.mapado.net/2016/5/9/toto.jpg'
+      '//img.mapado.net/2016/5/9/toto.jpg'
     );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,6 +53,21 @@ describe('UrlBuilder tests', () => {
       '//img.mapado.net/2016/5/9/toto.jpg_thumbs/400-300.blackwhite=1.jpg'
     );
   });
+
+  test('allowwepb option', () => {
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg')).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', null, null)).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', 0, 0)).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/0-0.jpg'
+    );
+    expect(UrlBuilder.buildUrl('2016/5/9/toto.jpg', null, null, { allowwebp: true })).toBe(
+      '//img.mapado.net/2016/5/9/toto.jpg_thumbs/0-0.jpg'
+    );
+  });
 });
 
 describe('const import', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function buildUrl(
     image = host + image;
   }
 
-  if (null !== width || null !== height) {
+  if (null !== width || null !== height || !!options) {
     let extension: string | null = _getExt(image);
     if (extension.length > 4) {
       // this is weird, as we added the host previously the extension will be something like `net/2016/5/9/toto`
@@ -38,11 +38,14 @@ export function buildUrl(
 
     image += `_thumbs/${width ?? 0}-${height ?? 0}`;
 
-    if (options) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    if (Object.entries(options).filter(([key, value]) => key !== 'allowwebp')) {
       image += '.';
 
       Object.entries(options).map((option) => {
-        image += `${option[0]}=${option[1]};`;
+        if (option[0] !== 'allowwebp') {
+          image += `${option[0]}=${option[1]};`;
+        }
       });
 
       image = image.substring(0, image.length - 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
 export function buildUrl(
   imageParam: null | undefined | '',
-  width?: number,
-  height?: number,
+  width?: number | null,
+  height?: number | null,
   options?: Record<string, unknown>
 ): undefined;
 
 export function buildUrl(
   imageParam: string,
-  width?: number,
-  height?: number,
+  width?: number | null,
+  height?: number | null,
   options?: Record<string, unknown>
 ): string;
 
 export function buildUrl(
   imageParam: null | undefined | string,
-  width = 0,
-  height = 0,
+  width: number | null = null,
+  height: number | null = null,
   options = {}
 ): string | undefined {
   if (!imageParam) {
@@ -25,21 +25,18 @@ export function buildUrl(
   let image: string = imageParam;
 
   if (!image.match(new RegExp('^//img([1-3])?.mapado.net/'))) {
-    const host = _getHost(image);
+    const host = '//img.mapado.net/';
     image = host + image;
   }
 
-  if (width > 0) {
+  if (null !== width || null !== height) {
     let extension: string | null = _getExt(image);
     if (extension.length > 4) {
       // this is weird, as we added the host previously the extension will be something like `net/2016/5/9/toto`
       extension = null;
     }
 
-    image += `_thumbs/${width}`;
-    if (height > 0) {
-      image += `-${height}`;
-    }
+    image += `_thumbs/${width ?? 0}-${height ?? 0}`;
 
     if (options) {
       image += '.';
@@ -57,19 +54,6 @@ export function buildUrl(
   }
 
   return image;
-}
-
-/**
- * @private
- */
-function _getHost(image: string): string {
-  let shard = '';
-  const matches = new RegExp('^[0-9]{4}/[0-9]{1,2}/([0-9]{1,2})').exec(image);
-  if (matches) {
-    const firstMatch = parseInt(matches[1], 10) % 2;
-    shard = firstMatch > 0 ? firstMatch.toString() : ''; // remove "0"
-  }
-  return `//img${shard}.mapado.net/`;
 }
 
 /**


### PR DESCRIPTION
### Nouveau comportement

Les nouveaux serveurs d'image sont http2.

[Grace au multiplexage apporté par http2](https://www.cloudflare.com/fr-fr/learning/performance/http2-vs-http1.1/), on n'a plus besoin de séparer les calls sur le serveur (entre img.mapado.net et img1.mapado.net)

Par ailleurs, on permet à présent un redimensionnement basé sur une hauteur (et pas seulement une largeur), ce qui est particulièrement pratique pour un logo affiché sur une ligne dont on connait la hauteur, mais dont la largeur peut varier.

### Tache Clickup

🧑‍🔧 